### PR TITLE
Remove dependency on clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@
 cmake_minimum_required (VERSION 3.2.2)
 project (roulette CXX)
 
-set (CMAKE_C_COMPILER "/usr/bin/clang")
-set (CMAKE_CXX_COMPILER "/usr/bin/clang++")
-
 if (NOT CMAKE_BUILD_TYPE MATCHES DEBUG)
   add_definitions(-DNDEBUG)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,11 @@ RUN apt-get update && apt-get install -y \
         build-essential \
         wget \
         cmake \
-        clang \
         libboost-all-dev \
         libgtest-dev \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Use clang compiler
-RUN export CC=/usr/bin/clang
-RUN export CXX=/usr/bin/clang++
 
 # Install gtest for importing by CMake
 RUN install -d gtest_build && \


### PR DESCRIPTION
Allow users to compile with their favorite compiler by setting the CC and CXX variables appropriately.