### PR TITLE
Avoid problem with large powers of small numbers

### DIFF
--- a/src/roulette/math.cpp
+++ b/src/roulette/math.cpp
@@ -31,7 +31,7 @@ namespace roulette {
         [](double x) { return std::sin(x) - x*std::cos(x); },
         0,
         2*M_PI,
-        90
+        450
       );
 
       while (theta < 0) theta += 2*M_PI;
@@ -46,7 +46,7 @@ namespace roulette {
         [](double x) { return std::cos(x) + x*std::sin(x); },
         0,
         2*M_PI,
-        90
+        450
       );
 
       while (theta < 0) theta += 2*M_PI;

--- a/test/math_test.h
+++ b/test/math_test.h
@@ -9,14 +9,14 @@ using namespace roulette;
 
 TEST(MathTest, test_sin) {
   for (double theta = -0.5; theta < 3*M_PI; theta += 0.15) {
-    // Verify within 0.05% of actual value
-    EXPECT_LE(std::abs(std::sin(theta) - math::sin(theta)), 0.0005 * std::abs(std::sin(theta)));
+    // Verify within 0.002% of actual value
+    EXPECT_LE(std::abs(std::sin(theta) - math::sin(theta)), 0.00002 * std::abs(std::sin(theta)));
   }
 }
 
 TEST(MathTest, test_cos) {
   for (double theta = -0.5; theta < 3*M_PI; theta += 0.15) {
-    // Verify within 0.05% of actual value
-    EXPECT_LE(std::abs(std::cos(theta) - math::cos(theta)), 0.0005 * std::abs(std::cos(theta)));
+    // Verify within 0.002% of actual value
+    EXPECT_LE(std::abs(std::cos(theta) - math::cos(theta)), 0.00002 * std::abs(std::cos(theta)));
   }
 }


### PR DESCRIPTION
When the size of the matrix increases too much, the recursive relation has the `double` value bottom out at zero, causing mayhem and NaNs.  Since the matrix we want to invert is a [tridiagonal matrix](https://en.wikipedia.org/wiki/Tridiagonal_matrix) with the same values along the diagonal, and the same values on the off-diagonals, it is possible to solve the recursion relation analytically.  It is a second order recurrence relation, with

```
theta_i = a_i * d^i
where d = -(delta x)^2 / 6
and a_i = ((2 + sqrt(3))^i + (2 - sqrt(3))^i) / 2 sqrt(3)
```

Using this form allows us to find a form for the elements of the matrix inverse where the powers of `d` cancel out nicely, and floating point problems with dividing and multiplying by a small number too much is avoided.  This allows us to push the number of points used to interpolate up if so desired.