### PR TITLE
Restriction too strict for fast math::sin/cos

### DIFF
--- a/test/geometries/ellipse_test.h
+++ b/test/geometries/ellipse_test.h
@@ -19,7 +19,7 @@ TEST(GeometryEllipseTest, ellipse_test) {
   ThreeVector u1 = ThreeVector(1,2,0).direction_unit_vector();
   ThreeVector u2 = ThreeVector(0,0,1).direction_unit_vector();
 
-  for (int i = 0; i < 20; ++i) {
+  for (int i = 0; i < 100; ++i) {
     auto three_vector = ellipse.sample(generator);
 
     EXPECT_EQ(2*three_vector(0), three_vector(1));

--- a/test/geometries/geometry_factory_test.h
+++ b/test/geometries/geometry_factory_test.h
@@ -109,7 +109,7 @@ TEST(GeometryFactoryTest, geometry_factory_spherical_shell_test) {
   )));
 
   auto v = shell->sample(generator);
-  EXPECT_NEAR((v - ThreeVector(2, 1, -1)).magnitude(), 1.5, 0.00001);
+  EXPECT_NEAR((v - ThreeVector(2, 1, -1)).magnitude(), 1.5, 0.0005);
 
   EXPECT_THROW(
     auto shell = geometries::GeometryFactory::geometry(Json::json_document_from_file_or_string(std::string(
@@ -133,7 +133,7 @@ TEST(GeometryFactoryTest, geometry_factory_hemispherical_shell_test) {
   )));
 
   auto v = shell->sample(generator);
-  EXPECT_NEAR((v - ThreeVector(1,1,1)).magnitude(), 3, 0.00002);
+  EXPECT_NEAR((v - ThreeVector(1,1,1)).magnitude(), 3, 0.0005);
   EXPECT_GT((v - ThreeVector(1,1,1))(0), 0);
 
   EXPECT_THROW(

--- a/test/geometries/hemispherical_shell_test.h
+++ b/test/geometries/hemispherical_shell_test.h
@@ -12,9 +12,9 @@ TEST(GeometryHemisphericalShellTest, hemispherical_shell_test) {
   RandomGenerator generator;
   geometries::HemisphericalShell shell(center, apex);
 
-  for (int i = 0; i < 20; ++i) {
+  for (int i = 0; i < 100; ++i) {
     auto three_vector = shell.sample(generator);
-    EXPECT_NEAR((three_vector - center).magnitude(), 2, 0.0001);
+    EXPECT_NEAR((three_vector - center).magnitude(), 2, 0.0005);
     EXPECT_GT((three_vector - center).dot(apex-center), 0);
   }
 }

--- a/test/geometries/spherical_shell_test.h
+++ b/test/geometries/spherical_shell_test.h
@@ -12,9 +12,9 @@ TEST(GeometrySphericalShellTest, spherical_shell_test) {
   RandomGenerator generator;
   geometries::SphericalShell shell(center, radius);
 
-  for (int i = 0; i < 20; ++i) {
+  for (int i = 0; i < 100; ++i) {
     auto three_vector = shell.sample(generator);
-    EXPECT_NEAR((three_vector - center).magnitude(), radius, 0.0001);
+    EXPECT_NEAR((three_vector - center).magnitude(), radius, 0.0005);
   }
 }
 


### PR DESCRIPTION
Test fails sometimes due to small error present in fast sin/cos calculations.  Need to loosen floating point comparison.