### PR TITLE
Should voxelate original grid

### DIFF
--- a/include/roulette/i_voxel_grid.h
+++ b/include/roulette/i_voxel_grid.h
@@ -27,6 +27,8 @@ namespace roulette {
       typedef std::function<double(double distance, size_t xi, size_t yi, size_t zi)> voxel_iterator;
 
     public:
+      virtual ~IVoxelGrid() {};
+
       virtual size_t nx() const = 0;
       virtual size_t ny() const = 0;
       virtual size_t nz() const = 0;

--- a/src/roulette/phantom.cpp
+++ b/src/roulette/phantom.cpp
@@ -67,7 +67,7 @@ namespace roulette {
     int nz = (original_phantom.nz() + sz - 1) / sz;
 
     // Assume regular grid!
-    auto voxel_grid = std::dynamic_pointer_cast<const RegularVoxelGrid>(this->voxel_grid());
+    auto voxel_grid = std::dynamic_pointer_cast<const RegularVoxelGrid>(original_phantom.voxel_grid());
     if (!voxel_grid) throw std::runtime_error("Cannot cast voxel grid to RegularVoxelGrid");
 
     double delta_x = voxel_grid->delta_x() * sx;


### PR DESCRIPTION
Previously would try to voxelate current voxel grid in constructor, which does not exist yet, so would get a `nullptr` no matter what.