### PR TITLE
Add fluence to Rectangle geometry

### DIFF
--- a/include/roulette/geometries/rectangle.h
+++ b/include/roulette/geometries/rectangle.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include "roulette/geometries/geometry.h"
+#include "roulette/distributions/fluence_distribution.h"
 #include "roulette/pdf.h"
 
 namespace roulette {
@@ -11,6 +12,8 @@ namespace roulette {
         const ThreeVector m_p0;
         const ThreeVector m_u1;
         const ThreeVector m_u2;
+
+        std::shared_ptr<const distributions::FluenceDistribution> m_fluence;
 
         std::shared_ptr<const Pdf> m_u_pdf;
         std::shared_ptr<const Pdf> m_v_pdf;

--- a/src/roulette/geometries/rectangle.cpp
+++ b/src/roulette/geometries/rectangle.cpp
@@ -29,29 +29,40 @@ namespace roulette {
         ThreeVector(data["top_right"])
       );
 
-      if (data.HasMember("u_pdf")) {
-        rectangle->m_u_pdf = std::make_shared<const Pdf>(data["u_pdf"]);
-        if (rectangle->m_u_pdf->min() != 0) { throw std::runtime_error("PDF must start at 0"); }
-        if (rectangle->m_u_pdf->max() != 1) { throw std::runtime_error("PDF must end at 1"); }
+      if (data.HasMember("fluence")) {
+        rectangle->m_fluence = std::make_shared<const distributions::FluenceDistribution>(TwoTensor(data["fluence"]));
       }
       else {
-        rectangle->m_u_pdf = std::make_shared<const Pdf>(0, 1);
-      }
+        if (data.HasMember("u_pdf")) {
+          rectangle->m_u_pdf = std::make_shared<const Pdf>(data["u_pdf"]);
+          if (rectangle->m_u_pdf->min() != 0) { throw std::runtime_error("PDF must start at 0"); }
+          if (rectangle->m_u_pdf->max() != 1) { throw std::runtime_error("PDF must end at 1"); }
+        }
+        else {
+          rectangle->m_u_pdf = std::make_shared<const Pdf>(0, 1);
+        }
 
-      if (data.HasMember("v_pdf")) {
-        rectangle->m_v_pdf = std::make_shared<const Pdf>(data["v_pdf"]);
-        if (rectangle->m_v_pdf->min() != 0) { throw std::runtime_error("PDF must start at 0"); }
-        if (rectangle->m_v_pdf->max() != 1) { throw std::runtime_error("PDF must end at 1"); }
-      }
-      else {
-        rectangle->m_v_pdf = std::make_shared<const Pdf>(0, 1);
+        if (data.HasMember("v_pdf")) {
+          rectangle->m_v_pdf = std::make_shared<const Pdf>(data["v_pdf"]);
+          if (rectangle->m_v_pdf->min() != 0) { throw std::runtime_error("PDF must start at 0"); }
+          if (rectangle->m_v_pdf->max() != 1) { throw std::runtime_error("PDF must end at 1"); }
+        }
+        else {
+          rectangle->m_v_pdf = std::make_shared<const Pdf>(0, 1);
+        }
       }
 
       return rectangle;
     }
 
     ThreeVector Rectangle::sample(RandomGenerator& generator) const {
-      return m_p0 + (*m_u_pdf)(generator) * m_u1 + (*m_v_pdf)(generator) * m_u2;
+      if (m_fluence) {
+        auto index = m_fluence->index(generator);
+        return m_p0 + (std::get<0>(index) + generator.uniform()) / ((double)m_fluence->nx()) * m_u1 + (std::get<1>(index) + generator.uniform()) / ((double)m_fluence->ny()) * m_u2;
+      }
+      else {
+        return m_p0 + (*m_u_pdf)(generator) * m_u1 + (*m_v_pdf)(generator) * m_u2;
+      }
     }
   }
 }

--- a/test/geometries/geometry_factory_test.h
+++ b/test/geometries/geometry_factory_test.h
@@ -66,6 +66,41 @@ TEST(GeometryFactoryTest, geometry_factory_rectangle_pdf_test) {
   }
 }
 
+TEST(GeometryFactoryTest, geometry_factory_rectangle_fluence_test) {
+  RandomGenerator generator;
+  auto rectangle = geometries::GeometryFactory::geometry(Json::json_document_from_file_or_string(std::string(
+    "{ \
+      \"type\": \"Rectangle\", \
+      \"bottom_left\": [0, 0, 0], \
+      \"bottom_right\": [2, 0, 0], \
+      \"top_right\": [2, 2, 0], \
+      \"fluence\": [[1,0],[0,1]] \
+    }"
+  )));
+
+  // Fluence gives only along diagonal, so in range [0,1)x[0,1) or [1,2)x[1,2)
+  for (int i = 0; i < 10; ++i) {
+    auto v = rectangle->sample(generator);
+
+    if (v(0) >= 1) {
+      EXPECT_GE(v(0), 1);
+      EXPECT_LT(v(0), 2);
+
+      EXPECT_GE(v(1), 1);
+      EXPECT_LT(v(1), 2);
+    }
+    else {
+      EXPECT_GE(v(0), 0);
+      EXPECT_LT(v(0), 1);
+
+      EXPECT_GE(v(1), 0);
+      EXPECT_LT(v(1), 1);
+    }
+
+    EXPECT_EQ(v(2), 0);
+  }
+}
+
 TEST(GeometryFactoryTest, geometry_factory_rectangle_test) {
   RandomGenerator generator;
   auto rectangle = geometries::GeometryFactory::geometry(Json::json_document_from_file_or_string(std::string(


### PR DESCRIPTION
Similar to `Beam` source, can define a fluence grid to sample from a general rectangular (parallelogram) shape.